### PR TITLE
Pinned cloudbuild maven image to maven:3.6-jdk-8

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -41,7 +41,7 @@ steps:
       path: /root
 
   - id: COMPILE_AND_PUSH_CONTAINER
-    name: 'maven:3.6-jdk-8'
+    name: 'maven:3.6-jdk-11'
     env:
     - 'SHORT_SHA=$SHORT_SHA'
     - 'BRANCH_NAME=$BRANCH_NAME'

--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -7,7 +7,7 @@ steps:
     # This is ugly because of
     # https://github.com/GoogleContainerTools/jib/issues/1500#issuecomment-466207421
   - id: FIX_DOCKER
-    name: gcr.io/cloud-builders/mvn
+    name: gcr.io/cloud-builders/gsutil
     waitFor: ['-']
     dir: /root
     entrypoint: bash
@@ -41,11 +41,13 @@ steps:
       path: /root
 
   - id: COMPILE_AND_PUSH_CONTAINER
-    name: 'gcr.io/cloud-builders/mvn'
+    name: 'maven:3.6-jdk-8'
     env:
     - 'SHORT_SHA=$SHORT_SHA'
     - 'BRANCH_NAME=$BRANCH_NAME'
     args:
+    - mvn
+    - -B
     - compile
     - jib:build
     - "-Dmaven.test.skip=true"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
       path: /root
 
   - id: TESTING
-    name: 'maven:3.6-jdk-8'
+    name: 'maven:3.6-jdk-11'
     args: ['mvn', '-B', 'test']
     volumes:
     - name: user.home

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,8 +22,8 @@ steps:
       path: /root
 
   - id: TESTING
-    name: 'gcr.io/cloud-builders/mvn'
-    args: ['test']
+    name: 'maven:3.6-jdk-8'
+    args: ['mvn', '-B', 'test']
     volumes:
     - name: user.home
       path: /root

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
         <http-client.version>4.5.5</http-client.version>
 		<influxdb-java.version>2.17</influxdb-java.version>
 
@@ -119,14 +119,6 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>11</source>
-					<target>11</target>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,127 +1,128 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.rackspacecloud.metrics</groupId>
-	<artifactId>query-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
+  <groupId>com.rackspacecloud.metrics</groupId>
+  <artifactId>query-service</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-	<name>query-service</name>
-	<description>Demo project for Spring Boot</description>
+  <name>query-service</name>
+  <description>Demo project for Spring Boot</description>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.6.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.2.6.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
-        <http-client.version>4.5.5</http-client.version>
-		<influxdb-java.version>2.17</influxdb-java.version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>11</java.version>
+    <http-client.version>4.5.5</http-client.version>
+    <influxdb-java.version>2.17</influxdb-java.version>
 
-		<!-- Pass on right value to publish the docker image to the registry -->
-		<docker.image.prefix>gcr.io/PROJECT_ID</docker.image.prefix>
-		<docker.image.latest>latest</docker.image.latest>
-	</properties>
+    <!-- Pass on right value to publish the docker image to the registry -->
+    <docker.image.prefix>gcr.io/PROJECT_ID</docker.image.prefix>
+    <docker.image.latest>latest</docker.image.latest>
+  </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
 
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.influxdb</groupId>
-			<artifactId>influxdb-java</artifactId>
-			<version>${influxdb-java.version}</version>
-		</dependency>
+    <dependency>
+      <groupId>org.influxdb</groupId>
+      <artifactId>influxdb-java</artifactId>
+      <version>${influxdb-java.version}</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>${http-client.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-core</artifactId>
-			<version>RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-influx</artifactId>
-			<version>1.1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-stackdriver</artifactId>
-			<version>1.1.1</version>
-		</dependency>
-	</dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${http-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-influx</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-stackdriver</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+  </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
 
-            <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>2.1.0</version>
-                <configuration>
-                  <from>
-                    <image>openjdk:11.0.6-slim</image>
-                  </from>
-                  <to>
-                        <image>${docker.image.prefix}/metrics-query-service</image>
-                        <tags>
-                            <tag>${project.version}</tag>
-                            <tag>${env.SHORT_SHA}</tag>
-                            <tag>${env.BRANCH_NAME}</tag>
-                         </tags>
-                    </to>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
-                <configuration>
-                    <!-- disabling this to resolve build issue on Linux:
-                    Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter -->
-                    <useSystemClassLoader>false</useSystemClassLoader>
-                </configuration>
-            </plugin>
-		</plugins>
-	</build>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>2.1.0</version>
+        <configuration>
+          <from>
+            <image>openjdk:11.0.6-slim</image>
+          </from>
+          <to>
+            <image>${docker.image.prefix}/metrics-query-service</image>
+            <tags>
+              <tag>${project.version}</tag>
+              <tag>${env.SHORT_SHA}</tag>
+              <tag>${env.BRANCH_NAME}</tag>
+            </tags>
+          </to>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <!-- disabling this to resolve build issue on Linux:
+          Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter -->
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>2.1.0</version>
                 <configuration>
-                    <to>
+                  <from>
+                    <image>openjdk:11.0.6-slim</image>
+                  </from>
+                  <to>
                         <image>${docker.image.prefix}/metrics-query-service</image>
                         <tags>
                             <tag>${project.version}</tag>


### PR DESCRIPTION
Fixing deploy failure where Java 8 (class file version 52.0) ended up trying run code compiled with Java 11 (class file version 55.0):

```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/rackspacecloud/metrics/queryservice/QueryServiceApplication has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:495)
```