### PR TITLE
Corrected request mapping for grafana's access to query-service

### DIFF
--- a/src/main/java/com/rackspacecloud/metrics/queryservice/configuration/CombinedSecurityConfig.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/configuration/CombinedSecurityConfig.java
@@ -55,8 +55,8 @@ public class CombinedSecurityConfig {
             http
                     .httpBasic().disable()
                     .csrf().disable()
-                    .antMatcher("/grafana-query/**")
-                    .authorizeRequests().antMatchers("/grafana-query/**")
+                    .antMatcher("/query/**")
+                    .authorizeRequests().antMatchers("/query/**")
                     .hasIpAddress(securityProperties.getWhitelistedIpRange());
         }
     }

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/controllers/QueryController.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/controllers/QueryController.java
@@ -30,14 +30,15 @@ public class QueryController {
 
     /**
      * Admin or support level query. Intended to be used by a grafana frontend.
+     * Grafana will append <code>/query</code> to the URL of the InfluxDB datasource configured.
      * Allow more free-form querying.
      * @param dbName - the alphanumeric tenant ID
      * @param queryString - an influxdb query
      * @return
      */
-    @GetMapping("/grafana-query")
+    @GetMapping("/query")
     @Timed(value = "query.service", extraTags = {"query.type","query.grafana"})
-    public QueryResult query(
+    public QueryResult grafanaQuery(
             final @RequestParam(value = "db", required = true) String dbName, //dbName = tenantId
             final @RequestParam("q") String queryString) {
         return queryService.query(dbName, queryString);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,7 +74,10 @@ management:
         auto-create-db: true
 
 security:
-  whitelistedIpRange: "192.168.0.0/16"
+  # grafana is told to access query-service via host.docker.internal,
+  # which gets routed by com.docker.vpnkit (on Mac's Docker Desktop)
+  # and finally contacts query-service via loopback
+  whitelistedIpRange: "127.0.0.1/32"
   whitelistedRoles: ["ROLE_COMPUTE_DEFAULT","COMPUTE_DEFAULT"]
 ---
 spring:

--- a/src/test/java/com/rackspacecloud/metrics/queryservice/QueryControllerTest.java
+++ b/src/test/java/com/rackspacecloud/metrics/queryservice/QueryControllerTest.java
@@ -49,7 +49,7 @@ public class QueryControllerTest {
     public void query_validTenantIdAndPayloadReturnsListOfMaps() throws Exception {
         when(queryServiceImpl.query(anyString(), anyString())).thenReturn(new QueryResult());
 
-        QueryResult queryResult = controller.query("1234", "queryString");
+        QueryResult queryResult = controller.grafanaQuery("1234", "queryString");
 
         Assert.assertNotNull("output is null", queryResult);
     }

--- a/src/test/java/com/rackspacecloud/metrics/queryservice/QueryControllerTest.java
+++ b/src/test/java/com/rackspacecloud/metrics/queryservice/QueryControllerTest.java
@@ -58,7 +58,7 @@ public class QueryControllerTest {
     public void test_GlobalExceptionHandler_getMethod_nonExistingTenant_throwsRouteNotFoundException() throws Exception {
         doThrow(RouteNotFoundException.class).when(queryServiceImpl).query(anyString(), anyString());
 
-        this.mockMvc.perform(get("/grafana-query?db=telegraf&q=SELECT mean(\"usage_user\")" +
+        this.mockMvc.perform(get("/query?db=telegraf&q=SELECT mean(\"usage_user\")" +
                 "FROM \"cpu\" WHERE time >= 1549513924084ms and time <= 1549514901143ms GROUP BY time(10s) fill(0)"))
                 .andExpect(status().isNotFound())
                 .andExpect(content().string("{\"message\":null,\"rootCause\":null}"));
@@ -68,7 +68,7 @@ public class QueryControllerTest {
     public void test_GlobalExceptionHandler_getMethod_badQuery_throwsInvalidQueryException() throws Exception {
         doThrow(InvalidQueryException.class).when(queryServiceImpl).query(anyString(), anyString());
 
-        this.mockMvc.perform(get("/grafana-query?db=telegraf&q=SELECT mean(\"usage_user\")" +
+        this.mockMvc.perform(get("/query?db=telegraf&q=SELECT mean(\"usage_user\")" +
                 "FROM \"cpu\" WHERE time >= 1549513924084ms and time <= 1549514901143ms GROUP BY time(10s) fill(0)"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("{\"message\":null,\"rootCause\":null}"));
@@ -78,7 +78,7 @@ public class QueryControllerTest {
     public void test_GlobalExceptionHandler_getMethod_randomException_throwsException() throws Exception {
         doThrow(RuntimeException.class).when(queryServiceImpl).query(anyString(), anyString());
 
-        this.mockMvc.perform(get("/grafana-query?db=telegraf&q=SELECT mean(\"usage_user\")" +
+        this.mockMvc.perform(get("/query?db=telegraf&q=SELECT mean(\"usage_user\")" +
                 "FROM \"cpu\" WHERE time >= 1549513924084ms and time <= 1549514901143ms GROUP BY time(10s) fill(0)"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().string("{\"message\":null,\"rootCause\":null}"));


### PR DESCRIPTION
# What

Grafana derives the InfluxDB datasource URL by appending `/query` to the datasource URL cofigured, so `/grafana-query` wasn't lining up with what Grafana was actually doing.

With this change https://github.com/racker/ceres-test-infrastructure/pull/5/files#diff-4e5e90c6228fd48698d074241c2ba760R59 in the repose configuration, the whitelist no longer needs to be hardcoded to assume people's computer is on a `192.168.*` network.

# How to test

Using the pre-configured datasource added here https://github.com/racker/ceres-test-infrastructure/pull/5/files#diff-8c4c68f4786ff99790177b399b47ebf0R4-R9 and confirm that the measurement names appear as expected.