### PR TITLE
Unstubbed dev route provider just enough to match ingest behaviour

### DIFF
--- a/http-client.env.json
+++ b/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "localhost": {
+    "tenantId": "MAAS-account-name-1"
+  }
+}

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/configuration/QueryServiceConfiguration.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/configuration/QueryServiceConfiguration.java
@@ -3,29 +3,21 @@ package com.rackspacecloud.metrics.queryservice.configuration;
 import com.rackspacecloud.metrics.queryservice.providers.DevTestTenantRouteProvider;
 import com.rackspacecloud.metrics.queryservice.providers.ProdTenantRouteProvider;
 import com.rackspacecloud.metrics.queryservice.providers.RouteProvider;
-import org.influxdb.InfluxDB;
+import com.rackspacecloud.metrics.queryservice.services.InfluxDBPool;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 @Configuration
 public class QueryServiceConfiguration {
     @Value("${tenant-routing-service.url}")
     private String tenantRoutingServiceUrl;
 
-    @Bean
-    ConcurrentMap<String, InfluxDB> urlInfluxDBInstanceMap() {
-        return new ConcurrentHashMap<>();
-    }
-
     @Bean(name = "routeProvider")
     @Profile({"development", "test"})
-    public RouteProvider devTestTenantRouteProvider() {
-        return new DevTestTenantRouteProvider(tenantRoutingServiceUrl);
+    public RouteProvider devTestTenantRouteProvider(InfluxDBPool influxDBPool) {
+        return new DevTestTenantRouteProvider(tenantRoutingServiceUrl, influxDBPool);
     }
 
     @Bean(name = "routeProvider")

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/services/InfluxDBPool.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/services/InfluxDBPool.java
@@ -1,0 +1,25 @@
+package com.rackspacecloud.metrics.queryservice.services;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provides a mechanism to lazy-create {@link InfluxDB} instances for requested instance URLs.
+ */
+@Component
+public class InfluxDBPool {
+  private ConcurrentMap<String/*InfluxDB URL*/, InfluxDB> urlInfluxDBInstanceMap =
+      new ConcurrentHashMap<>();
+
+  public InfluxDB getInstance(String influxDbUrl) {
+    return urlInfluxDBInstanceMap.computeIfAbsent(influxDbUrl, this::connect);
+  }
+
+  private InfluxDB connect(String influxDbUrl) {
+    return InfluxDBFactory.connect(influxDbUrl)
+      .setLogLevel(InfluxDB.LogLevel.BASIC);
+  }
+}

--- a/testing.http
+++ b/testing.http
@@ -1,0 +1,1 @@
+GET http://localhost:8080/v1.0/tenant/{{tenantId}}/intelligence-format-query/measurements


### PR DESCRIPTION
# Resolves

Partially addresses https://jira.rax.io/browse/CERES-287

# What

Using the diagram I reverse engineered out of the ingestion code https://github.com/racker/ceres-ingestion-service/pull/51 , I discovered that the "stubbed" behavior of ingestion hardcodes a reference to one InfluxDB and one database "db_0".

The `DevTestTenantRouteProvider` is actually pretty close to stubbing routes to InfluxDB in the same way (`getRoute` -> `getStubbedRoutes`). What was lacking was that the measurements retrieval was returning a hardcoded list. 

# How

Use a [`SHOW MEASUREMENTS`](https://docs.influxdata.com/influxdb/v1.8/query_language/explore-schema/#show-measurements) to retrieve a semi-real list of measurements from InfluxDB. I say "semi-real" because it doesn't probably narrow those measurements that were applicable for the requested tenant.

At this provides enough of a solution to locally validate end-to-end that metrics ingested into InfluxDB can be retrieved back out.