### PR TITLE
Fix measurement endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ curl --request GET \
 * Method: `GET`
 * Query parameters
     * `measurement`
-    * `begin` : ISO Date Format yyyy-MM-dd
-    * `end` : ISO Date Format yyyy-MM-dd
+    * `begin` : ISO Date Format yyyy-MM-ddThh:mm
+    * `end` : ISO Date Format yyyy-MM-ddThh:mm
   
 ## Setup
 

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/controllers/QueryController.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/controllers/QueryController.java
@@ -72,7 +72,7 @@ public class QueryController {
     @GetMapping("/v1.0/tenant/{tenantId}/intelligence-format-query/measurement-tags")
     @Timed(value = "query.service", extraTags = {"query.type","query.intelligence.measurement-tags"})
     public List<?> intelligenceFormattedQueryGetMeasurementTags(
-            final @RequestParam("measurement") String measurement,
+            final @RequestParam String measurement,
             final @PathVariable String tenantId) { // Use repose tenantId
         log.debug("Called url:[{}] with tenantId: [{}], measurement: [{}]",
                 "/intelligence-format-query/measurement-tags", tenantId, measurement);
@@ -87,7 +87,7 @@ public class QueryController {
     @GetMapping("/v1.0/tenant/{tenantId}/intelligence-format-query/measurement-fields")
     @Timed(value = "query.service", extraTags = {"query.type","query.intelligence.measurements-fields"})
     public List<?> intelligenceFormattedQueryGetMeasurementDescription(
-            final @RequestParam("measurement") String measurement,
+            final @RequestParam String measurement,
             final @PathVariable String tenantId) { // Use repose tenantId
         log.debug("Called url:[{}] with tenantId: [{}], measurement: [{}]",
                 "/intelligence-format-query/measurement-fields", tenantId, measurement);
@@ -106,8 +106,8 @@ public class QueryController {
     public List<?> intelligenceFormattedQueryGetMeasurementSeriesByTime(
             final @RequestParam("measurement") String measurement,
             // ISO 8601
-            final @RequestParam("begin") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime begin,
-            final @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime end,
+            final @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime begin,
+            final @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
             final @PathVariable String tenantId) { // Use repose tenantId
 
         log.debug("Called url:[{}] with tenantId: [{}], measurement: [{}]" +
@@ -128,14 +128,16 @@ public class QueryController {
 
         List<QueryDomainOutput> outputs = new ArrayList<>();
 
-        for(QueryResult.Result result : results){
-            for(QueryResult.Series series : result.getSeries()){
-                QueryDomainOutput output = new QueryDomainOutput();
-                output.setName(series.getName());
-                output.setColumns(series.getColumns());
-                output.setTags(series.getTags());
-                output.setValuesCollection(series.getValues());
-                outputs.add(output);
+        for (QueryResult.Result result : results) {
+            if (result.getSeries() != null) {
+                for (QueryResult.Series series : result.getSeries()) {
+                    QueryDomainOutput output = new QueryDomainOutput();
+                    output.setName(series.getName());
+                    output.setColumns(series.getColumns());
+                    output.setTags(series.getTags());
+                    output.setValuesCollection(series.getValues());
+                    outputs.add(output);
+                }
             }
         }
 

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/services/QueryServiceImpl.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/services/QueryServiceImpl.java
@@ -98,44 +98,41 @@ public class QueryServiceImpl implements QueryService {
     public QueryResult getMeasurementTags(String tenantId, String measurement) {
         TenantRoutes.TenantRoute route = getTenantRoutes(tenantId, measurement);
 
-        Query query = BoundParameterQuery.QueryBuilder.newQuery("SHOW TAG KEYS from $measurement")
-                .forDatabase(route.getDatabaseName())
-                .bind("measurement", measurement)
-                .create();
+        Query query = BoundParameterQuery.QueryBuilder.newQuery(
+            String.format("%s %s", PREFIX_FOR_SHOW_TAGS_FOR_MEASUREMENT, measurement))
+            .forDatabase(route.getDatabaseName())
+            .create();
 
         InfluxDB influxDB = getInfluxDB(route);
-        QueryResult results = influxDB.query(query);
-        return results;
+        return influxDB.query(query);
     }
 
     @Override
     public QueryResult getMeasurementFields(String tenantId, String measurement) {
         TenantRoutes.TenantRoute route = getTenantRoutes(tenantId, measurement);
 
-        Query query = BoundParameterQuery.QueryBuilder.newQuery("SHOW FIELD KEYS from $measurement")
-                .forDatabase(route.getDatabaseName())
-                .bind("measurement", measurement)
-                .create();
+        Query query = BoundParameterQuery.QueryBuilder.newQuery(
+            String.format("%s %s", PREFIX_FOR_SHOW_FIELDS_FOR_MEASUREMENT, measurement))
+            .forDatabase(route.getDatabaseName())
+            .create();
 
         InfluxDB influxDB = getInfluxDB(route);
-        QueryResult results = influxDB.query(query);
-        return results;
+        return influxDB.query(query);
     }
 
     @Override
     public QueryResult getMeasurementSeriesForTimeInterval(String tenantId, String measurement, LocalDateTime begin, LocalDateTime end) {
         TenantRoutes.TenantRoute route = getTenantRoutes(tenantId, measurement);
 
-        Query query = BoundParameterQuery.QueryBuilder.newQuery("SELECT * from $measurement where timestamp>=$begin and timestamp<=$end")
-                .forDatabase(route.getDatabaseName())
-                .bind("measurement", measurement)
-                .bind("begin", begin)
-                .bind("end", end)
-                .create();
+        Query query = BoundParameterQuery.QueryBuilder.newQuery(
+            String.format("SELECT * from %s where timestamp>=$begin and timestamp<=$end", measurement))
+            .forDatabase(route.getDatabaseName())
+            .bind("begin", begin)
+            .bind("end", end)
+            .create();
 
         InfluxDB influxDB = getInfluxDB(route);
-        QueryResult results = influxDB.query(query);
-        return results;
+        return influxDB.query(query);
     }
 
     @Override


### PR DESCRIPTION
# What

Fixes the measurement endpoint queries.

# How

`BoundParameterQuery.QueryBuilder` cannot `.bind` a value for the table name so we instead use `String.format` to populate that, but can continue to bind any other parameters.

Fixed a null handling bug.

Added time to `measurement-series-by-time` params.  I'd assume we'd want to specify a time in addition to the date - previously it was doing a mixture of both which led to errors.


## How to test

I haven't put enough time in to see if `/measurement-series-by-time` is actually working, but it doesn't error out anymore.

All tests pass and manual testing of all endpoints appears ok.

# Why

Fixing bugs.