### PR TITLE
Fix timestamp query handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ curl --request GET \
 * Method: `GET`
 * Query parameters
     * `measurement`
-    * `begin` : ISO Date Format yyyy-MM-ddThh:mm
-    * `end` : ISO Date Format yyyy-MM-ddThh:mm
+    * `begin` : ISO Date Format yyyy-MM-ddThh:mm:ssV (2020-05-08T22:01:35Z)
+    * `end` : ISO Date Format yyyy-MM-ddThh:mm:ssV (2020-05-09T12:01:35Z)
   
 ## Setup
 

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/services/QueryService.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/services/QueryService.java
@@ -1,9 +1,7 @@
 package com.rackspacecloud.metrics.queryservice.services;
 
+import java.time.Instant;
 import org.influxdb.dto.QueryResult;
-
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 
 public interface QueryService {
 
@@ -13,7 +11,7 @@ public interface QueryService {
 
     QueryResult getMeasurementFields(String tenantId, String measurement);
 
-    QueryResult getMeasurementSeriesForTimeInterval(String tenantId, String measurement, LocalDateTime begin, LocalDateTime end);
+    QueryResult getMeasurementSeriesForTimeInterval(String tenantId, String measurement, Instant begin, Instant end);
 
     // general-purpose grafana/admin access
     QueryResult query(String dbName, String queryString);

--- a/src/main/java/com/rackspacecloud/metrics/queryservice/services/QueryServiceImpl.java
+++ b/src/main/java/com/rackspacecloud/metrics/queryservice/services/QueryServiceImpl.java
@@ -6,7 +6,7 @@ import com.rackspacecloud.metrics.queryservice.exceptions.RouteNotFoundException
 import com.rackspacecloud.metrics.queryservice.providers.RouteProvider;
 import com.rackspacecloud.metrics.queryservice.providers.TenantRoutes;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -121,14 +121,14 @@ public class QueryServiceImpl implements QueryService {
     }
 
     @Override
-    public QueryResult getMeasurementSeriesForTimeInterval(String tenantId, String measurement, LocalDateTime begin, LocalDateTime end) {
+    public QueryResult getMeasurementSeriesForTimeInterval(String tenantId, String measurement, Instant begin, Instant end) {
         TenantRoutes.TenantRoute route = getTenantRoutes(tenantId, measurement);
 
         Query query = BoundParameterQuery.QueryBuilder.newQuery(
-            String.format("SELECT * from %s where timestamp>=$begin and timestamp<=$end", measurement))
+            String.format("SELECT * from %s where time >= $begin and time <= $end", measurement))
             .forDatabase(route.getDatabaseName())
-            .bind("begin", begin)
-            .bind("end", end)
+            .bind("begin", DateTimeFormatter.ISO_INSTANT.format(begin))
+            .bind("end", DateTimeFormatter.ISO_INSTANT.format(end))
             .create();
 
         InfluxDB influxDB = getInfluxDB(route);

--- a/src/test/java/com/rackspacecloud/metrics/queryservice/QueryServiceImplTests.java
+++ b/src/test/java/com/rackspacecloud/metrics/queryservice/QueryServiceImplTests.java
@@ -14,9 +14,9 @@ import com.rackspacecloud.metrics.queryservice.services.InfluxDBPool;
 import com.rackspacecloud.metrics.queryservice.services.QueryServiceImpl;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -338,13 +338,13 @@ public class QueryServiceImplTests {
 
         series.setColumns(columns);
         series.setValues(values);
-        result.setSeries(Arrays.asList(series));
+        result.setSeries(Collections.singletonList(series));
         QueryResult expectedQueryResult = new QueryResult();
-        expectedQueryResult.setResults(new ArrayList<>(Arrays.asList(result)));
+        expectedQueryResult.setResults(new ArrayList<>(Collections.singletonList(result)));
         mockedComponents("1234", "jvm_memory_used", expectedQueryResult);
 
         QueryResult qr = queryService.getMeasurementSeriesForTimeInterval("1234", "jvm_memory_used",
-                LocalDateTime.now().minusHours(6), LocalDateTime.now());
+                Instant.now().minusSeconds(6 * 60 * 60 /*6 hours*/), Instant.now());
 
         QueryResult.Series actualSeries = qr.getResults().get(0).getSeries().get(0);
 


### PR DESCRIPTION
# What

Fixes the `/measurement-series-by-time` endpoint.

# How

Parse timestamps correctly and query the correct `time` field.

## How to test

Manually + fixed existing tests.

# Why

This endpoint was previously silently erroring out due to an invalid query and then returning an empty list.