### PR TITLE
Tweak application settings

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+security:
+  whitelistedRoles: ["COMPUTE_DEFAULT", "CUSTOMER_ADMIN"]
 server:
   port: 8080
 spring:
@@ -27,13 +29,12 @@ security:
   # Disable IP whitelisting in development/test since Spring Security doesn't easily
   # allow for whitelisting loopback addresses for both IPv4 and IPv6
   whitelistedIpRange: ""
-  whitelistedRoles: ["COMPUTE_DEFAULT"]
 
 ---
 spring:
   profiles: development
   http:
-    log-request-details=true
+    log-request-details: true
 
 org:
   springframework:
@@ -42,7 +43,7 @@ org:
         mvc:
           method:
             annotation:
-              RequestMappingHandlerMapping=TRACE:
+              RequestMappingHandlerMapping: TRACE
 
 rest-template:
   request-config:
@@ -81,7 +82,6 @@ security:
   # Disable IP whitelisting in development/test since Spring Security doesn't easily
   # allow for whitelisting loopback addresses for both IPv4 and IPv6
   whitelistedIpRange: ""
-  whitelistedRoles: ["COMPUTE_DEFAULT"]
 ---
 spring:
   profiles: production
@@ -129,4 +129,3 @@ management:
 
 security:
   whitelistedIpRange: "10.40.0.0/14"
-  whitelistedRoles: ["COMPUTE_DEFAULT"]


### PR DESCRIPTION
Only `whitelistedIpRange` was being altered based on the profile so I moved `whitelistedRoles` to the top level and included `CUSTOMER_ADMIN` so non-cloud tenants would work.

I looked at helm for this setting and don't see it being overridden in there either, so those files will likely need to be tweaked further for real deploys to handle all scenarios.

Also tweaked a few other settings which were probably copied over from an `application.properties` file and not fully converted to the correct format.

